### PR TITLE
Remove unnecessary blocking call

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ VueBrowserUpdate.install = (Vue, opts) => {
       throw new Error('The plugin "browser-update" could not be loaded.');
     } else {
       if (!options.containerAsync) {
-        console.log('Load for', options.options);
         browserUpdate(options.options, options.test);
       }
     }


### PR DESCRIPTION
Blocking calls should be avoided in production.
`console.log()` is a blocking call, so unnecessary calls should be silencing.